### PR TITLE
added continue on error to html proofer

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,4 +39,5 @@ jobs:
         uses: athackst/htmlproofer-action@main
         with:
           directory: ./
+          continue-on-error: true
           # End additional steps!!


### PR DESCRIPTION
added a continue on failure section for the htmlproofer, which should allow pull requests to go through without that error.